### PR TITLE
refactor, fix and polish fancify message command and add setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,16 @@ Contributions to this project are welcome! If you have ideas for new features, i
 4. Go to https://discord.com/developers/applications, create and set up a bot and invite it to a server
 5. Create a file in the root directory called `bot_token.py` and fill in your token:
    ```py
-   token = "<YOUR_DISCORD_BOT_TOKEN>"
+   token = "<DISCORD_BOT_TOKEN>"
    ```
-6. Create a file in the root directory called `variables.py`
+6. Create a file in the root directory called `variables.py` and fill it with ids of your bot and channels:
+   ```py
+   logs = <BOT_LOG_CHANNEL_ID>
+   intro_channel = <INTRO_CHANNEL_ID>
+   newsletter_broadcast_channel = <NEWSLETTER_CHANNEL_ID>
+   bot_id = <BOT_USER_ID>
+   ```
+   > These values are given as integers and must therefore not be quoted
 7. Start the bot using:
    ```bash
    python main.py

--- a/README.md
+++ b/README.md
@@ -12,6 +12,27 @@ readme placholder -->
 
 Contributions to this project are welcome! If you have ideas for new features, improvements, or bug fixes, please feel free to create a pull request. Be sure to review our contribution guidelines before getting started.
 
+### Develop Locally
+
+1. Clone the repo and navigate to it using a terminal
+2. Install python
+3. Install the dependencies using:
+   ```bash
+   pip install -r requirements.txt
+   ```
+   > You may need to use `pip3` instead of `pip`
+4. Go to https://discord.com/developers/applications, create and set up a bot and invite it to a server
+5. Create a file in the root directory called `bot_token.py` and fill in your token:
+   ```py
+   token = "<YOUR_DISCORD_BOT_TOKEN>"
+   ```
+6. Create a file in the root directory called `variables.py`
+7. Start the bot using:
+   ```bash
+   python main.py
+   ```
+   > You may need to use `python3` instead of `python`
+
 ## Support and Issues
 
 If you encounter any issues or have questions about using the Datapack Hub Helper Bot, please check our [FAQ](https://discord.datapackhub.net/faq) for common solutions. If your issue persists or you need further assistance, you can open an issue on our [GitHub repository](https://github.com/Datapack-Hub/bot/issues).

--- a/README.md
+++ b/README.md
@@ -15,18 +15,17 @@ Contributions to this project are welcome! If you have ideas for new features, i
 ### Develop Locally
 
 1. Clone the repo and navigate to it using a terminal
-2. Install python
-3. Install the dependencies using:
+2. Install the dependencies using:
    ```bash
    pip install -r requirements.txt
    ```
    > You may need to use `pip3` instead of `pip`
-4. Go to https://discord.com/developers/applications, create and set up a bot and invite it to a server
-5. Create a file in the root directory called `bot_token.py` and fill in your token:
+3. Go to https://discord.com/developers/applications, create and set up a bot and invite it to a server
+4. Create a file in the root directory called `bot_token.py` and fill in your token:
    ```py
    token = "<DISCORD_BOT_TOKEN>"
    ```
-6. Create a file in the root directory called `variables.py` and fill it with ids of your bot and channels:
+5. Create a file in the root directory called `variables.py` and fill it with ids of your bot and channels:
    ```py
    logs = <BOT_LOG_CHANNEL_ID>
    intro_channel = <INTRO_CHANNEL_ID>
@@ -34,7 +33,7 @@ Contributions to this project are welcome! If you have ideas for new features, i
    bot_id = <BOT_USER_ID>
    ```
    > These values are given as integers and must therefore not be quoted
-7. Start the bot using:
+6. Start the bot using:
    ```bash
    python main.py
    ```

--- a/main.py
+++ b/main.py
@@ -43,7 +43,7 @@ bot = commands.Bot(command_prefix="?", intents=intents, activity=activity)
 
 # * ADD COGS
 # Message Commands
-#bot.add_cog(fancify.FancifyCommand(bot))
+bot.add_cog(fancify.FancifyCommand(bot))
 
 # Slash Commands
 bot.add_cog(syntax.SyntaxCommand(bot))


### PR DESCRIPTION
I made the fancify command work and it should also handle marcos, say, me, snbt and stuff like that. I also added highlighting using `<THESE_-brackets here.>` _(since that's how I always do it lel)_

To test:
```mcfunction
execute as @e[type=cow,limit=1] if data storage mc:tst {data:{path:["with","json"]}} store result storage mc:tst data.stora int 1 run say @e[type=ender_dragon] +12
say something with run 12.5 -30
scoreboard players set .nice score 120
scoreboard players set @s <SCOREBOARD> 12
# this is a comment
execute as \
  @a run say \
  kill @e
execute as @e run \
  kill @r
kill @e[nbt={HurtTime:10s}]
$say @a[type=player] this is a macro say lmao
$tellraw @a[type=$(type)] {"text":"A friggin $(macro) var in a text lmao"}
tellraw [{multiline:"thing",\
  that:{is:"json",nr:12}, "it all": "works \
  now"}]
```

![image](https://github.com/Datapack-Hub/bot/assets/84644295/0db83090-4dca-4ea5-b4dc-9c616bed50d8)
